### PR TITLE
fix/#168 team form enter navigation

### DIFF
--- a/src/features/team/ui/TeamForm.tsx
+++ b/src/features/team/ui/TeamForm.tsx
@@ -94,6 +94,9 @@ const TeamForm = ({
       <form
         className="mt-6 flex flex-col"
         noValidate
+        onKeyDown={(event) => {
+          if (event.key === "Enter") event.preventDefault();
+        }}
         onSubmit={(event) => event.preventDefault()}
       >
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
## 변경 내용

<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->
- 팀 생성 폼 내부 input에서 Enter 키를 눌렀을 때 폼이 제출되는 문제를 막았습니다.
- Enter 키 입력으로 돌아가기 버튼이 실행되어 팀 목록으로 이동하던 문제를 해결했습니다.

## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #168

## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

## 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

### Before
<!-- 변경 전 스크린샷 -->
https://github.com/user-attachments/assets/818b5f7b-8959-4290-ae00-f26aa416ea69


### After
<!-- 변경 후 스크린샷 -->
https://github.com/user-attachments/assets/4d5f67a9-0cff-4231-bcdb-7516b74930ed

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다

## 기타 사항
