### PR TITLE
fix: 앱인도담 어드민 반응형 레이아웃 수정

### DIFF
--- a/src/features/manage-app-in/ui/index.tsx
+++ b/src/features/manage-app-in/ui/index.tsx
@@ -119,7 +119,7 @@ const AdminAppIn = () => {
         </div>
       </div>
 
-      <aside className="flex h-[70vh] min-h-0 min-w-0 w-full max-h-188.25 shrink-0 flex-col overflow-hidden rounded-large bg-background-surface p-4 sm:p-5 xl:w-88">
+      <aside className="flex h-[70vh] min-h-0 min-w-0 w-full max-h-188.25 shrink-0 flex-col overflow-hidden rounded-large bg-background-surface p-4 sm:p-5 xl:w-105.5">
         <h1 className="text-headline font-bold">릴리즈 요청 목록</h1>
         <div className="scrollbar mt-4 min-h-0 flex-1 overflow-y-auto pr-1">
           <div className="flex flex-col gap-4">
@@ -199,7 +199,7 @@ const AdminAppIn = () => {
 AdminAppIn.Skeleton = () => (
   <section className="flex w-full min-w-0 flex-col gap-4 xl:flex-row">
     <div className="h-[70vh] min-h-0 min-w-0 max-h-188.25 flex-1 rounded-large skeleton" />
-    <div className="h-[70vh] min-h-0 w-full max-h-188.25 shrink-0 rounded-large skeleton xl:w-88" />
+    <div className="h-[70vh] min-h-0 w-full max-h-188.25 shrink-0 rounded-large skeleton xl:w-105.5" />
   </section>
 );
 

--- a/src/features/manage-app-in/ui/index.tsx
+++ b/src/features/manage-app-in/ui/index.tsx
@@ -94,8 +94,8 @@ const AdminAppIn = () => {
 
   return (
     <section className="flex w-full min-w-0 flex-col gap-4 xl:flex-row xl:items-start">
-      <div className="h-188.25 min-w-0 flex-1 overflow-auto rounded-large bg-background-surface p-6">
-        <div className="min-w-201.25">
+      <div className="scrollbar h-[70vh] min-h-0 min-w-0 max-h-188.25 flex-1 overflow-auto rounded-large bg-background-surface p-4 sm:p-6">
+        <div className="w-full min-w-0">
           {rows.length ? (
             <Table data={rows} keys={APP_TABLE_KEYS} />
           ) : (
@@ -117,7 +117,7 @@ const AdminAppIn = () => {
         </div>
       </div>
 
-      <aside className="flex h-188.25 w-full shrink-0 flex-col overflow-hidden rounded-large bg-background-surface p-5 xl:w-105.5">
+      <aside className="flex h-[70vh] min-h-0 min-w-0 w-full max-h-188.25 shrink-0 flex-col overflow-hidden rounded-large bg-background-surface p-4 sm:p-5 xl:w-105.5">
         <h1 className="text-headline font-bold">릴리즈 요청 목록</h1>
         <div className="scrollbar mt-4 min-h-0 flex-1 overflow-y-auto pr-1">
           <div className="flex flex-col gap-4">
@@ -135,7 +135,7 @@ const AdminAppIn = () => {
                   {release.releaseUrl}
                 </a>
                 <div className="h-px w-full bg-border-normal" />
-                <div className="grid grid-cols-2 grid-rows-2 gap-x-6 gap-y-3 text-label">
+                <div className="grid grid-cols-1 gap-x-4 gap-y-3 text-label sm:grid-cols-2 sm:gap-x-6">
                   <div className="flex min-w-0 items-center gap-2 whitespace-nowrap">
                     <span className="font-bold text-text-secondary">팀명</span>
                     <span className="truncate font-semibold text-text-primary">
@@ -156,7 +156,7 @@ const AdminAppIn = () => {
                       {app.name}
                     </span>
                   </div>
-                  <div className="flex items-center justify-end gap-1">
+                  <div className="col-span-1 flex items-center justify-end gap-1 sm:col-span-2">
                     <FilledButton
                       disabled={isAllowing}
                       display="inline"
@@ -196,8 +196,8 @@ const AdminAppIn = () => {
 
 AdminAppIn.Skeleton = () => (
   <section className="flex w-full min-w-0 flex-col gap-4 xl:flex-row">
-    <div className="h-188.25 min-w-0 flex-1 rounded-large skeleton" />
-    <div className="h-188.25 w-full shrink-0 rounded-large skeleton xl:w-105.5" />
+    <div className="h-[70vh] min-h-0 min-w-0 max-h-188.25 flex-1 rounded-large skeleton" />
+    <div className="h-[70vh] min-h-0 w-full max-h-188.25 shrink-0 rounded-large skeleton xl:w-105.5" />
   </section>
 );
 

--- a/src/features/manage-app-in/ui/index.tsx
+++ b/src/features/manage-app-in/ui/index.tsx
@@ -17,6 +17,8 @@ const APP_TABLE_KEYS: TableKey[] = [
   ["서비스 표시", "90px"],
   ["상태 제어", "90px"],
 ];
+const getGithubDisplayUrl = (githubUrl: string) =>
+  githubUrl.replace(/^https?:\/\/github\.com\//, "");
 const getReleaseVersion = (releaseUrl: string) =>
   releaseUrl.split("/").filter(Boolean).pop()?.replace(/^v/, "") ?? "-";
 
@@ -50,7 +52,7 @@ const AdminAppIn = () => {
         rel="noreferrer"
         target="_blank"
       >
-        {app.githubUrl}
+        {getGithubDisplayUrl(app.githubUrl)}
       </a>
     ) : (
       "-"

--- a/src/features/manage-app-in/ui/index.tsx
+++ b/src/features/manage-app-in/ui/index.tsx
@@ -117,7 +117,7 @@ const AdminAppIn = () => {
         </div>
       </div>
 
-      <aside className="flex h-[70vh] min-h-0 min-w-0 w-full max-h-188.25 shrink-0 flex-col overflow-hidden rounded-large bg-background-surface p-4 sm:p-5 xl:w-105.5">
+      <aside className="flex h-[70vh] min-h-0 min-w-0 w-full max-h-188.25 shrink-0 flex-col overflow-hidden rounded-large bg-background-surface p-4 sm:p-5 xl:w-88">
         <h1 className="text-headline font-bold">릴리즈 요청 목록</h1>
         <div className="scrollbar mt-4 min-h-0 flex-1 overflow-y-auto pr-1">
           <div className="flex flex-col gap-4">
@@ -197,7 +197,7 @@ const AdminAppIn = () => {
 AdminAppIn.Skeleton = () => (
   <section className="flex w-full min-w-0 flex-col gap-4 xl:flex-row">
     <div className="h-[70vh] min-h-0 min-w-0 max-h-188.25 flex-1 rounded-large skeleton" />
-    <div className="h-[70vh] min-h-0 w-full max-h-188.25 shrink-0 rounded-large skeleton xl:w-105.5" />
+    <div className="h-[70vh] min-h-0 w-full max-h-188.25 shrink-0 rounded-large skeleton xl:w-88" />
   </section>
 );
 

--- a/src/routes/(role)/admin/_adminLayout/route.tsx
+++ b/src/routes/(role)/admin/_adminLayout/route.tsx
@@ -49,14 +49,16 @@ function RouteComponent() {
   }
 
   return (
-    <div className="flex h-fit min-h-0 flex-col gap-4">
-      <header className="large-container">
-        <SegmentedButton
-          data={pageData}
-          setData={setPages}
-          onBlockClick={(v) => navigate({ to: `/admin/${v}` })}
-          width="22.5rem"
-        />
+    <div className="flex h-fit min-h-0 min-w-0 flex-col gap-4">
+      <header className="large-container min-w-0 max-sm:p-4">
+        <div className="w-full max-w-[22.5rem]">
+          <SegmentedButton
+            data={pageData}
+            setData={setPages}
+            onBlockClick={(v) => navigate({ to: `/admin/${v}` })}
+            width="100%"
+          />
+        </div>
       </header>
       <Outlet />
     </div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -91,7 +91,7 @@ function RootComponent() {
 
   return (
     <div className="relative flex justify-center w-full h-screen bg-background-default">
-      <div className="flex justify-center w-lg max-w-lg grow min-h-0 gap-8">
+      <div className="flex min-w-0 w-full max-w-lg grow min-h-0 justify-center gap-8">
         <Sidebar
           isMobile={isMobile}
           isMobileSidebarOpen={isMobileSidebarOpen}
@@ -107,9 +107,9 @@ function RootComponent() {
 
         <main
           ref={mainRef}
-          className="flex grow min-h-0 flex-col overflow-y-auto py-7 sm:pr-8 max-sm:py-5 max-sm:px-5"
+          className="flex min-w-0 grow min-h-0 flex-col overflow-y-auto py-7 sm:pr-8 max-sm:py-5 max-sm:px-5"
         >
-          <div className="flex min-h-full flex-col">
+          <div className="flex min-w-0 min-h-full flex-col">
             <Outlet />
             <div className="h-9 shrink-0" />
           </div>


### PR DESCRIPTION
## 변경 내용

- 앱인도담 앱 목록 테이블의 명시적 최소 너비를 제거해 페이지 전체가 아닌 목록 패널 내부에서만 가로 스크롤되도록 수정했습니다.
- GitHub 주소는 이동 기능을 유지하면서 `github.com/` 뒤의 경로만 표시하도록 간소화했습니다.
- 관리자 탭과 레이아웃 flex 컨테이너에 반응형 너비 및 `min-w-0`을 적용했습니다.
- 앱 목록/릴리즈 요청 패널의 높이, 여백, 폼 그리드를 화면 크기에 맞게 조정했습니다.


## 관련 이슈

- Resolves #187
- See also #179


## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

정적 검증:
- Prettier 통과
- `tsc -b` 통과
- ESLint 오류 없음 (기존 warning 1건)
- Vite production build 통과


## 스크린샷 (UI 변경 시)

브라우저 수동 확인 전이라 Before/After 캡처는 첨부하지 않았습니다. 증상 및 기대 화면은 #187의 첨부 이미지를 참고해주세요.

### Before

- 앱 목록 테이블의 최소 너비가 상위 레이아웃을 밀어 페이지 전체 가로 오버플로가 발생했습니다.
- GitHub 주소가 전체 URL로 표시되었습니다.

### After

- 상위 레이아웃은 화면 너비를 유지하고, 필요한 가로 스크롤은 앱 목록 패널 내부에서만 발생하도록 수정했습니다.
- `https://github.com/dgswhs`가 `dgswhs`로 표시됩니다.


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항

- `develop`에는 앱인도담 기본 구현(#179)이 이미 포함되어 있으며, 이 PR은 반응형 레이아웃 수정 3개 파일만 포함합니다.