### PR TITLE
feature/#152-schedule-detail-dialog

### DIFF
--- a/src/features/get-schedule/ui/ScheduleEventItem.tsx
+++ b/src/features/get-schedule/ui/ScheduleEventItem.tsx
@@ -1,4 +1,6 @@
 import type { ScheduleEvent } from "@/entities/schedule/types";
+import { parseDate } from "@/shared/utils/parse-date";
+import { Dialog, useOverlay } from "@b1nd/dodam-design-system/components";
 import dayjs from "dayjs";
 
 interface ScheduleEventItemProps {
@@ -14,19 +16,57 @@ export const ScheduleEventItem = ({
   rowStartDate,
   rowEndDate,
 }: ScheduleEventItemProps) => {
+  const { open } = useOverlay();
   const startDate = dayjs(item.start);
   const endDate = dayjs(item.end);
   const isSingleDay = startDate.isSame(endDate, "day");
 
+  const openDetailDialog = () => {
+    open(({ close, exit, isOpen }) => (
+      <Dialog
+        open={isOpen}
+        title={item.title}
+        onClose={close}
+        onExited={exit}
+        closeOnDimmerClick
+      >
+        <div className="flex flex-col gap-4 w-full">
+          <div className="flex flex-col gap-2 text-body1">
+            <div className="flex gap-2">
+              <span className="text-text-secondary w-20 shrink-0">기간</span>
+              <span>
+                {parseDate(item.start)}
+                {!isSingleDay && ` ~ ${parseDate(item.end)}`}
+              </span>
+            </div>
+            <div className="flex gap-2">
+              <span className="text-text-secondary w-20 shrink-0">대상</span>
+              <span>{item.attendees.join(", ")}</span>
+            </div>
+          </div>
+          <Dialog.FilledButton role="assistive" onClick={close}>
+            닫기
+          </Dialog.FilledButton>
+        </div>
+      </Dialog>
+    ));
+  };
+
   if (isSingleDay) {
     return (
-      <div className="w-full flex items-center gap-1">
+      <button
+        type="button"
+        onClick={openDetailDialog}
+        className="w-full flex items-center gap-1 appearance-none border-0 bg-transparent p-0 font-[inherit] text-left"
+      >
         <span
           className="size-1.5 rounded-full shrink-0"
           style={{ backgroundColor: item.backgroundColor }}
         />
-        <span className="text-text-secondary overflow-hidden text-ellipsis text-nowrap">{item.title}</span>
-      </div>
+        <span className="text-text-secondary overflow-hidden text-ellipsis text-nowrap">
+          {item.title}
+        </span>
+      </button>
     );
   }
 
@@ -41,15 +81,17 @@ export const ScheduleEventItem = ({
     !cellDate.isAfter(segmentEnd, "day");
 
   return cellDate.isSame(segmentStart, "day") ? (
-    <div
-      className="h-5 rounded-[3px] px-1.5 text-static-white flex items-center whitespace-nowrap overflow-hidden relative z-10"
+    <button
+      type="button"
+      onClick={openDetailDialog}
+      className="h-5 rounded-[3px] px-1.5 text-static-white flex items-center whitespace-nowrap overflow-hidden relative z-10 appearance-none border-0 bg-transparent py-0 font-[inherit] text-left"
       style={{
         backgroundColor: item.backgroundColor,
         width: `calc(${spanDays * 100}% + ${spanDays - 1}px + ${1.05 * spanDays}rem - 1rem)`,
       }}
     >
       <span className="text-static-white overflow-hidden text-ellipsis text-nowrap">{item.title}</span>
-    </div>
+    </button>
   ) : isInSegmentRange ? (
     <div className="h-5" aria-hidden />
   ) : null;

--- a/src/features/get-schedule/ui/ScheduleEventItem.tsx
+++ b/src/features/get-schedule/ui/ScheduleEventItem.tsx
@@ -57,7 +57,7 @@ export const ScheduleEventItem = ({
       <button
         type="button"
         onClick={openDetailDialog}
-        className="w-full flex items-center gap-1 appearance-none border-0 bg-transparent p-0 font-[inherit] text-left"
+        className="w-full flex items-center gap-1 appearance-none border-0 bg-transparent p-0 font-[inherit] text-left cursor-pointer"
       >
         <span
           className="size-1.5 rounded-full shrink-0"
@@ -84,7 +84,7 @@ export const ScheduleEventItem = ({
     <button
       type="button"
       onClick={openDetailDialog}
-      className="h-5 rounded-[3px] px-1.5 text-static-white flex items-center whitespace-nowrap overflow-hidden relative z-10 appearance-none border-0 bg-transparent py-0 font-[inherit] text-left"
+      className="h-5 rounded-[3px] px-1.5 text-static-white flex items-center whitespace-nowrap overflow-hidden relative z-10 appearance-none border-0 bg-transparent py-0 font-[inherit] text-left cursor-pointer"
       style={{
         backgroundColor: item.backgroundColor,
         width: `calc(${spanDays * 100}% + ${spanDays - 1}px + ${1.05 * spanDays}rem - 1rem)`,


### PR DESCRIPTION
## 변경 내용

일정 캘린더 항목을 클릭하면 상세 일정 Dialog를 표시합니다.

## 관련 이슈

- Resolves #152

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

## 스크린샷 (UI 변경 시)

### Before
<img width="1512" height="982" alt="스크린샷 2026-08-20 오후 3 44 00" src="https://github.com/user-attachments/assets/323973fe-32e4-491b-a298-cef06d355e3c" />


### After
<img width="1512" height="982" alt="스크린샷 2026-08-20 오후 3 44 27" src="https://github.com/user-attachments/assets/8401baca-3b00-4278-adb1-b9bbf9854e3f" />


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다
- [x] Breaking Changes가 없습니다

## 기타 사항

hover가 아닌 click으로만 상세 Dialog를 엽니다.